### PR TITLE
Add linker flags to eliminate problems with compilation on mingw

### DIFF
--- a/exprtk.go
+++ b/exprtk.go
@@ -1,6 +1,6 @@
 package exprtk
 
-// #cgo CXXFLAGS: -std=c++11
+// #cgo CXXFLAGS: -flto -fuse-linker-plugin -std=c++11
 // #cgo LDFLAGS: -L.
 // #include "exprtkwrapper.h"
 import "C"


### PR DESCRIPTION
The problem in mention here: https://stackoverflow.com/questions/31890021/mingw-too-many-sections-bug-while-compiling-huge-header-file-in-qt